### PR TITLE
Add image carousel, env files, and uid fixes

### DIFF
--- a/foodswiper-frontend/.env
+++ b/foodswiper-frontend/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=https://foodswiper-backend.onrender.com

--- a/foodswiper-frontend/.env.development
+++ b/foodswiper-frontend/.env.development
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8080

--- a/foodswiper-frontend/src/components/SwipeCard.css
+++ b/foodswiper-frontend/src/components/SwipeCard.css
@@ -22,6 +22,27 @@
 
 .card-emoji { font-size: 6rem; line-height: 1; margin-bottom: 1.5rem; }
 
+.card-img-wrap { position: relative; width: 100%; margin-bottom: 1.25rem; }
+
+.card-img {
+  width: 100%; height: 220px;
+  object-fit: cover;
+  border-radius: 16px;
+  pointer-events: none;
+  display: block;
+}
+
+.card-img-dots {
+  display: flex; justify-content: center; gap: 6px;
+  position: absolute; bottom: 8px; left: 0; right: 0;
+}
+.dot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: rgba(255,255,255,0.5);
+  transition: background 0.2s;
+}
+.dot.active { background: #fff; }
+
 .card-info { text-align: center; }
 
 .card-type-badge {

--- a/foodswiper-frontend/src/components/SwipeCard.tsx
+++ b/foodswiper-frontend/src/components/SwipeCard.tsx
@@ -27,8 +27,14 @@ interface Props {
 
 export default function SwipeCard({ item, index = 0, onSwipe }: Props) {
   const [drag, setDrag] = useState({ x: 0, y: 0, dragging: false });
+  const [imgIndex, setImgIndex] = useState(0);
   const startPos = useRef<{ x: number; y: number } | null>(null);
   const cardRef = useRef<HTMLDivElement>(null);
+
+  const allImages = [
+    ...(item.imageUrl ? [item.imageUrl] : []),
+    ...(item.photos?.map(p => p.url) ?? []),
+  ].filter((url, i, arr) => arr.indexOf(url) === i); // dedupe
 
   const bgColor = BG_COLORS[item.id % BG_COLORS.length];
   const emoji = getEmoji(item.name);
@@ -51,7 +57,11 @@ export default function SwipeCard({ item, index = 0, onSwipe }: Props) {
   };
 
   const handlePointerUp = () => {
-    if (direction) onSwipe(item, direction === "right");
+    if (direction) {
+      onSwipe(item, direction === "right");
+    } else if (!drag.dragging || (Math.abs(drag.x) < 5 && Math.abs(drag.y) < 5)) {
+      if (allImages.length > 1) setImgIndex(i => (i + 1) % allImages.length);
+    }
     setDrag({ x: 0, y: 0, dragging: false });
     startPos.current = null;
   };
@@ -72,7 +82,21 @@ export default function SwipeCard({ item, index = 0, onSwipe }: Props) {
       {direction === "right" && <div className="swipe-label like">LIKE ✓</div>}
       {direction === "left" && <div className="swipe-label nope">NOPE ✕</div>}
 
-      <div className="card-emoji">{emoji}</div>
+      {allImages.length > 0
+        ? (
+          <div className="card-img-wrap">
+            <img className="card-img" src={allImages[imgIndex]} alt={item.name} />
+            {allImages.length > 1 && (
+              <div className="card-img-dots">
+                {allImages.map((_, i) => (
+                  <span key={i} className={`dot${i === imgIndex ? " active" : ""}`} />
+                ))}
+              </div>
+            )}
+          </div>
+        )
+        : <div className="card-emoji">{emoji}</div>
+      }
       <div className="card-info">
         <span className="card-type-badge">{item.type || "Food"}</span>
         <h2 className="card-name">{item.name}</h2>

--- a/foodswiper-frontend/src/pages/Favorites.css
+++ b/foodswiper-frontend/src/pages/Favorites.css
@@ -25,6 +25,12 @@
 
 .fav-emoji { font-size: 3rem; margin-bottom: 0.75rem; }
 
+.fav-img {
+  width: 100%; height: 130px;
+  object-fit: cover; border-radius: 14px;
+  margin-bottom: 0.75rem; pointer-events: none;
+}
+
 .fav-type {
   display: inline-block; background: rgba(179,90,43,0.1); color: var(--primary);
   font-size: 0.68rem; font-weight: 800; padding: 3px 10px;

--- a/foodswiper-frontend/src/pages/Favorites.tsx
+++ b/foodswiper-frontend/src/pages/Favorites.tsx
@@ -18,7 +18,7 @@ function getEmoji(name: string = ""): string {
 
 export default function Favorites() {
   const { user } = useAuth();
-  const userId = Number(user?.sub ?? user?.id ?? 1);
+  const userId = user?.id ?? 0;
   const { likes, loading, remove } = useFavorites(userId);
 
   if (loading) {
@@ -50,7 +50,10 @@ export default function Favorites() {
             return (
               <div key={swipe.id} className="fav-card" style={{ background: BG_COLORS[item.id % BG_COLORS.length] }}>
                 <button className="fav-remove" onClick={() => remove(swipe.id)} title="Remove">✕</button>
-                <div className="fav-emoji">{getEmoji(item.name)}</div>
+                {item.imageUrl
+                  ? <img className="fav-img" src={item.imageUrl} alt={item.name} />
+                  : <div className="fav-emoji">{getEmoji(item.name)}</div>
+                }
                 <span className="fav-type">{item.type || "Food"}</span>
                 <h3 className="fav-name">{item.name}</h3>
                 <p className="fav-desc">{item.description || "No description."}</p>

--- a/foodswiper-frontend/src/pages/Groups.tsx
+++ b/foodswiper-frontend/src/pages/Groups.tsx
@@ -5,7 +5,7 @@ import "./Groups.css";
 
 export default function Groups() {
   const { user } = useAuth();
-  const userId = Number(user?.sub ?? user?.id ?? 1);
+  const userId = user?.id ?? 0;
   const { groups, loading, create } = useGroups(userId);
   const [newName, setNewName] = useState("");
   const [creating, setCreating] = useState(false);

--- a/foodswiper-frontend/src/pages/Swipe.tsx
+++ b/foodswiper-frontend/src/pages/Swipe.tsx
@@ -5,7 +5,7 @@ import "./Swipe.css";
 
 export default function Swipe() {
   const { user } = useAuth();
-  const userId = Number(user?.sub ?? user?.id ?? 1);
+  const userId = user?.id ?? 0;
   const { feed, loading, empty, swipe } = useFeed(userId);
 
   const handleButton = (liked: boolean) => {

--- a/foodswiper-frontend/src/types/index.ts
+++ b/foodswiper-frontend/src/types/index.ts
@@ -11,11 +11,18 @@ export interface User {
   group_ids?: number[];
 }
 
+export interface Photo {
+  id: number;
+  url: string;
+}
+
 export interface Item {
   id: number;
   name: string;
   description?: string;
   type?: string;
+  imageUrl?: string;
+  photos?: Photo[];
 }
 
 export interface SwipeHistory {


### PR DESCRIPTION
Add environment files (VITE_API_URL for production and development) and enable item image support across the app. SwipeCard: display image(s) with a small carousel/dots, allow tapping to advance images, and include new styles. Favorites: show image thumbnail when available (falls back to emoji). Pages (Swipe, Groups, Favorites): normalize userId extraction to use user?.id ?? 0. Types: introduce Photo and add imageUrl/photos to Item. Misc: CSS tweaks for card/favorite images and pagination dots.